### PR TITLE
Update README.md - fix URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,6 @@ And you can even make up your own set of digits to get weirder:
 ## Installing
 
 ```bash
-pip install pip+https://github.com/darrenpmeyer/python-weirdbase.git
+pip install git+https://github.com/darrenpmeyer/python-weirdbase.git
 ```
 


### PR DESCRIPTION
git install URL was `pip+https://...` when it should be `git+https://...`